### PR TITLE
Feature/story2.4

### DIFF
--- a/Assets/_Recovery/0 (1).unity
+++ b/Assets/_Recovery/0 (1).unity
@@ -600,7 +600,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3431018974941178782, guid: 9b6135a0dd8140045ab175ad224ce2f3, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 3431018974941178782, guid: 9b6135a0dd8140045ab175ad224ce2f3, type: 3}
       propertyPath: m_LocalRotation.y
@@ -608,7 +608,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3431018974941178782, guid: 9b6135a0dd8140045ab175ad224ce2f3, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 3431018974941178782, guid: 9b6135a0dd8140045ab175ad224ce2f3, type: 3}
       propertyPath: m_AnchoredPosition.x

--- a/Assets/_Recovery/0 (1).unity.meta
+++ b/Assets/_Recovery/0 (1).unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 896b3e521eab91141aaaebabd96415be
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/game/Prefab/Characters/SkeletonEnemyStats.asset
+++ b/Assets/game/Prefab/Characters/SkeletonEnemyStats.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6217254614b453b4982de6783125d881, type: 3}
   m_Name: SkeletonEnemyStats
   m_EditorClassIdentifier: Assembly-CSharp::EnemyStats
-  maxHealth: 100
+  maxHealth: 50
   attackDamage: 10
   movementSpeed: 2
   isBoss: 0

--- a/Assets/game/Prefab/enemySkeleton.prefab
+++ b/Assets/game/Prefab/enemySkeleton.prefab
@@ -4776,7 +4776,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAttack
   enemyStats: {fileID: 11400000, guid: 966554bea77238a44a8c61f0d52ea1cf, type: 2}
-  attackRange: 2.6
+  attackRange: 2.5
   attackInterval: 1.5
 --- !u!114 &-4632863046824613060
 MonoBehaviour:

--- a/Assets/game/Prefab/enemySkeleton.prefab
+++ b/Assets/game/Prefab/enemySkeleton.prefab
@@ -4776,6 +4776,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAttack
   enemyStats: {fileID: 11400000, guid: 966554bea77238a44a8c61f0d52ea1cf, type: 2}
+  attackRange: 2.6
+  attackInterval: 1.5
 --- !u!114 &-4632863046824613060
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/game/Prefab/enemySkeleton.prefab
+++ b/Assets/game/Prefab/enemySkeleton.prefab
@@ -4762,6 +4762,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyMover
   enemyStats: {fileID: 11400000, guid: 966554bea77238a44a8c61f0d52ea1cf, type: 2}
+  stoppingDistance: 2.5
 --- !u!114 &-4331950187728672861
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/game/Scripts/EnemyAttack.cs
+++ b/Assets/game/Scripts/EnemyAttack.cs
@@ -9,6 +9,17 @@ public class EnemyAttack : MonoBehaviour
     private float attackDamage;
     private float attackTimer;
     private Transform playerTarget;
+    private bool playerIsDead;
+    
+    void OnEnable()
+    {
+        CombatEvents.OnDeath += HandleDeath;
+    }
+
+    void OnDisable()
+    {
+        CombatEvents.OnDeath -= HandleDeath;
+    }
 
     void Start()
     {
@@ -20,17 +31,26 @@ public class EnemyAttack : MonoBehaviour
         }
 
         attackDamage = enemyStats.AttackDamage;
-        Debug.Log(gameObject.name + " attack damage loaded: " + attackDamage);
+        //Debug.Log(gameObject.name + " attack damage loaded: " + attackDamage);
 
         GameObject playerObj = GameObject.FindGameObjectWithTag("Player");
-        if (playerObj != null)
-        {
-            playerTarget = playerObj.transform;
-        }
-        else
+        if (playerObj == null)
         {
             Debug.LogError("Player object not found in the scene.");
             enabled = false;
+            return;
+        }
+        playerTarget = playerObj.transform;
+        PlayerHealth playerHealth = playerTarget.GetComponent<PlayerHealth>();
+
+        if (playerHealth != null)
+        {
+            playerIsDead = playerHealth.IsDead;
+            //Debug.Log(gameObject.name + " detected player death state on spawn: " + playerIsDead);
+        }
+        else
+        {
+            Debug.LogWarning("PlayerHealth component not found on Player.");
         }
 
         if (attackInterval <= 0)
@@ -51,6 +71,7 @@ public class EnemyAttack : MonoBehaviour
     void Update()
     {
         if (playerTarget == null) return;
+        if (playerIsDead) return;
 
         attackTimer += Time.deltaTime;
 
@@ -65,8 +86,18 @@ public class EnemyAttack : MonoBehaviour
 
     void Attack()
     {
+        if (playerIsDead) return;
+
         CombatEvents.TriggerAttack(transform, playerTarget);
         CombatEvents.TriggerHit(transform, playerTarget, attackDamage);
         Debug.Log(gameObject.name + " attacked " + playerTarget.name + " for " + attackDamage + " damage.");
+    }
+
+    void HandleDeath(Transform character)
+    {
+        if (character.CompareTag("Player"))
+        {
+            playerIsDead = true;
+        }
     }
 }

--- a/Assets/game/Scripts/EnemyAttack.cs
+++ b/Assets/game/Scripts/EnemyAttack.cs
@@ -3,8 +3,12 @@ using UnityEngine;
 public class EnemyAttack : MonoBehaviour
 {
     [SerializeField] private EnemyStats enemyStats;
-    private Transform playerTarget;
+    [SerializeField] private float attackRange = 1f;
+    [SerializeField] private float attackInterval = 1.5f;
+    
     private float attackDamage;
+    private float attackTimer;
+    private Transform playerTarget;
 
     void Start()
     {
@@ -17,15 +21,40 @@ public class EnemyAttack : MonoBehaviour
 
         attackDamage = enemyStats.AttackDamage;
         Debug.Log(gameObject.name + " attack damage loaded: " + attackDamage);
+
+        GameObject playerObj = GameObject.FindGameObjectWithTag("Player");
+        if (playerObj != null)
+        {
+            playerTarget = playerObj.transform;
+        }
+        else
+        {
+            Debug.LogError("Player object not found in the scene.");
+            enabled = false;
+        }
+
+        attackTimer = attackInterval; // Start the timer so the enemy can attack immediately
     }
 
     void Update()
     {
+        if (playerTarget == null) return;
+
+        attackTimer += Time.deltaTime;
+
+        float distanceToPlayer = Vector2.Distance(transform.position, playerTarget.position);
+        if (distanceToPlayer <= attackRange && attackTimer >= attackInterval)
+        {
+            Attack();
+            attackTimer = 0f; // Reset the timer after attacking
+        }
         
     }
 
     void Attack()
     {
-        //CombatEvents.TriggerAttack(transform, playerTarget);
+        CombatEvents.TriggerAttack(transform, playerTarget);
+        CombatEvents.TriggerHit(transform, playerTarget, attackDamage);
+        Debug.Log(gameObject.name + " attacked " + playerTarget.name + " for " + attackDamage + " damage.");
     }
 }

--- a/Assets/game/Scripts/EnemyAttack.cs
+++ b/Assets/game/Scripts/EnemyAttack.cs
@@ -33,6 +33,18 @@ public class EnemyAttack : MonoBehaviour
             enabled = false;
         }
 
+        if (attackInterval <= 0)
+        {
+            Debug.LogError(gameObject.name + " attack interval must be greater than zero.");
+            attackInterval = 1f;
+        }
+
+        if (attackRange <= 0)
+        {
+            Debug.LogError(gameObject.name + " attack range must be greater than zero.");
+            attackRange = 2.6f;
+        }
+
         attackTimer = attackInterval; // Start the timer so the enemy can attack immediately
     }
 

--- a/Assets/game/Scripts/EnemyAttack.cs
+++ b/Assets/game/Scripts/EnemyAttack.cs
@@ -5,12 +5,12 @@ public class EnemyAttack : MonoBehaviour
     [SerializeField] private EnemyStats enemyStats;
     [SerializeField] private float attackRange = 1f;
     [SerializeField] private float attackInterval = 1.5f;
-    
+
     private float attackDamage;
     private float attackTimer;
     private Transform playerTarget;
     private bool playerIsDead;
-    
+
     void OnEnable()
     {
         CombatEvents.OnDeath += HandleDeath;
@@ -81,7 +81,7 @@ public class EnemyAttack : MonoBehaviour
             Attack();
             attackTimer = 0f; // Reset the timer after attacking
         }
-        
+
     }
 
     void Attack()

--- a/Assets/game/Scripts/EnemyHealth.cs
+++ b/Assets/game/Scripts/EnemyHealth.cs
@@ -29,7 +29,7 @@ public class EnemyHealth : MonoBehaviour
 
     void Update()
     {
-        
+
     }
 
     void HandleHit(Transform attacker, Transform target, float damage)
@@ -44,6 +44,18 @@ public class EnemyHealth : MonoBehaviour
         if (isDead) return;
         isDead = true;
 
+        EnemyMover mover = GetComponent<EnemyMover>();
+        if (mover != null)
+        {
+            mover.enabled = false;
+        }
+
+        EnemyAttack attack = GetComponent<EnemyAttack>();
+        if (attack != null)
+        {
+            attack.enabled = false;
+        }
+
         Debug.Log(gameObject.name + " has died.");
         CombatEvents.TriggerDeath(transform);
         Destroy(gameObject);
@@ -57,7 +69,7 @@ public class EnemyHealth : MonoBehaviour
             return;
         }
         currentHealth -= damage;
-        Debug.Log(gameObject.name + " took " + damage + " damage. Current health: " + currentHealth);
+        //Debug.Log(gameObject.name + " took " + damage + " damage. Current health: " + currentHealth);
         if (currentHealth <= 0)
         {
 

--- a/Assets/game/Scripts/EnemyMover.cs
+++ b/Assets/game/Scripts/EnemyMover.cs
@@ -40,6 +40,13 @@ public class EnemyMover : MonoBehaviour
         {
             Debug.LogError("Player object not found in the scene.");
             enabled = false;
+            return;
+        }
+        PlayerHealth playerHealth = playerTarget.GetComponent<PlayerHealth>();
+
+        if (playerHealth != null)
+        {
+            playerIsDead = playerHealth.IsDead;
         }
     }
 

--- a/Assets/game/Scripts/EnemyMover.cs
+++ b/Assets/game/Scripts/EnemyMover.cs
@@ -6,6 +6,17 @@ public class EnemyMover : MonoBehaviour
     [SerializeField] private float stoppingDistance = 0.75f;
     private float moveSpeed;
     private Transform playerTarget;
+    private bool playerIsDead;
+
+    void OnEnable()
+    {
+        CombatEvents.OnDeath += HandleDeath;
+    }
+
+    void OnDisable()
+    {
+        CombatEvents.OnDeath -= HandleDeath;
+    }
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
@@ -36,7 +47,8 @@ public class EnemyMover : MonoBehaviour
     void Update()
     {
         if (playerTarget == null) return;
-        
+        if (playerIsDead) return;
+
         float distanceToPlayer = Vector2.Distance(transform.position, playerTarget.position);
         if (distanceToPlayer <= stoppingDistance) return;
 
@@ -46,7 +58,15 @@ public class EnemyMover : MonoBehaviour
             moveSpeed * Time.deltaTime
         );
         transform.position = nextPosition;
-        
-        
+
+
+    }
+
+    void HandleDeath(Transform character)
+    {
+        if (character.CompareTag("Player"))
+        {
+            playerIsDead = true;
+        }
     }
 }

--- a/Assets/game/Scripts/EnemyMover.cs
+++ b/Assets/game/Scripts/EnemyMover.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 public class EnemyMover : MonoBehaviour
 {
     [SerializeField] private EnemyStats enemyStats;
+    [SerializeField] private float stoppingDistance = 0.75f;
     private float moveSpeed;
     private Transform playerTarget;
 
@@ -34,15 +35,18 @@ public class EnemyMover : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if(playerTarget != null)
-        {
-            Vector2 nextPosition = Vector2.MoveTowards(
-                transform.position,
-                playerTarget.position,
-                moveSpeed * Time.deltaTime
-            );
-            transform.position = nextPosition;
-        }
+        if (playerTarget == null) return;
+        
+        float distanceToPlayer = Vector2.Distance(transform.position, playerTarget.position);
+        if (distanceToPlayer <= stoppingDistance) return;
+
+        Vector2 nextPosition = Vector2.MoveTowards(
+            transform.position,
+            playerTarget.position,
+            moveSpeed * Time.deltaTime
+        );
+        transform.position = nextPosition;
+        
         
     }
 }

--- a/Assets/game/Scripts/EnemySpawner.cs
+++ b/Assets/game/Scripts/EnemySpawner.cs
@@ -5,11 +5,43 @@ public class EnemySpawner : MonoBehaviour
     [SerializeField] private GameObject enemyPrefab;
     [SerializeField] private float spawnInterval = 5f;
     private float spawnTimer;
+    private bool playerIsDead;
+
+    void OnEnable()
+    {
+        CombatEvents.OnDeath += HandleDeath;
+    }
+
+    void OnDisable()
+    {
+        CombatEvents.OnDeath -= HandleDeath;
+    }
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
         spawnTimer = spawnInterval;
+        GameObject playerObj = GameObject.FindGameObjectWithTag("Player");
+        if (playerObj == null)
+        {
+            Debug.LogError("Player object not found in the scene.");
+            enabled = false;
+            return;
+        }
+        PlayerHealth playerHealth = playerObj.GetComponent<PlayerHealth>();
+        if (playerHealth != null)
+        {
+            if (playerIsDead = playerHealth.IsDead)
+            {
+                Debug.Log("Player is already dead at spawner start. No enemies will spawn.");
+                return;
+            }
+        }
+        else
+        {
+            Debug.LogWarning("PlayerHealth component not found on Player.");
+        }
+
 
         if (enemyPrefab == null)
         {
@@ -34,6 +66,14 @@ public class EnemySpawner : MonoBehaviour
 
     void SpawnEnemy()
     {
+        if (playerIsDead) return;
         GameObject enemy = Instantiate(enemyPrefab, transform.position, Quaternion.identity);
+    }
+    void HandleDeath(Transform character)
+    {
+        if (character.CompareTag("Player"))
+        {
+            playerIsDead = true;
+        }
     }
 }

--- a/Assets/game/Scripts/PlayerAutoAttack.cs
+++ b/Assets/game/Scripts/PlayerAutoAttack.cs
@@ -29,16 +29,16 @@ public class PlayerAutoAttack : MonoBehaviour
             PerformAttack();
             attackTimer = attackInterval;
         }
-        
+
     }
 
-   void PerformAttack()
+    void PerformAttack()
     {
         Transform target = FindTargetInRange();
 
         if (target == null)
         {
-            Debug.Log("No target in range for auto attack.");
+            //Debug.Log("No target in range for auto attack.");
             return;
         }
 

--- a/Assets/game/Scripts/PlayerHealth.cs
+++ b/Assets/game/Scripts/PlayerHealth.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+
+public class PlayerHealth : MonoBehaviour
+{
+    [SerializeField] private float maxHealth = 100f;
+    private float currentHealth;
+    private bool isDead = false;
+
+    void OnEnable()
+    {
+        CombatEvents.OnHit += HandleHit;
+    }
+
+    void OnDisable()
+    {
+        CombatEvents.OnHit -= HandleHit;
+    }
+
+    void Start()
+    {
+        if (maxHealth == 0)
+        {
+            Debug.LogError(gameObject.name + " has zero max health.");
+            enabled = false;
+            return;
+        }
+        currentHealth = maxHealth;
+    }
+
+    void Update()
+    {
+        
+    }
+
+    void HandleHit(Transform attacker, Transform target, float damage)
+    {
+        if (target != transform) return;
+
+        TakeDamage(damage);
+    }
+
+    void Die()
+    {
+        if (isDead) return;
+        isDead = true;
+
+        Debug.Log(gameObject.name + " has died.");
+        CombatEvents.TriggerDeath(transform);
+        // Implement respawn or game over logic here
+    }
+
+    public void TakeDamage(float damage)
+    {
+        if (damage < 0)
+        {
+            Debug.LogWarning("Damage must be greater than zero.");
+            return;
+        }
+        currentHealth -= damage;
+        Debug.Log(gameObject.name + " took " + damage + " damage. Current health: " + currentHealth);
+
+        if (currentHealth <= 0)
+        {
+            Die();
+        }
+    }
+}

--- a/Assets/game/Scripts/PlayerHealth.cs
+++ b/Assets/game/Scripts/PlayerHealth.cs
@@ -43,6 +43,8 @@ public class PlayerHealth : MonoBehaviour
     {
         if (isDead) return;
         isDead = true;
+        transform.rotation = Quaternion.Euler(0f, 0f, -90f);
+        GetComponent<PlayerAutoAttack>().enabled = false;
 
         Debug.Log(gameObject.name + " has died.");
         CombatEvents.TriggerDeath(transform);
@@ -51,6 +53,8 @@ public class PlayerHealth : MonoBehaviour
 
     public void TakeDamage(float damage)
     {
+        if (isDead) return;
+
         if (damage < 0)
         {
             Debug.LogWarning("Damage must be greater than zero.");

--- a/Assets/game/Scripts/PlayerHealth.cs
+++ b/Assets/game/Scripts/PlayerHealth.cs
@@ -5,6 +5,7 @@ public class PlayerHealth : MonoBehaviour
     [SerializeField] private float maxHealth = 100f;
     private float currentHealth;
     private bool isDead = false;
+    public bool IsDead => isDead;
 
     void OnEnable()
     {
@@ -45,7 +46,7 @@ public class PlayerHealth : MonoBehaviour
         isDead = true;
         transform.rotation = Quaternion.Euler(0f, 0f, -90f);
         GetComponent<PlayerAutoAttack>().enabled = false;
-
+        
         Debug.Log(gameObject.name + " has died.");
         CombatEvents.TriggerDeath(transform);
         // Implement respawn or game over logic here

--- a/Assets/game/Scripts/PlayerHealth.cs
+++ b/Assets/game/Scripts/PlayerHealth.cs
@@ -30,7 +30,7 @@ public class PlayerHealth : MonoBehaviour
 
     void Update()
     {
-        
+
     }
 
     void HandleHit(Transform attacker, Transform target, float damage)
@@ -46,7 +46,7 @@ public class PlayerHealth : MonoBehaviour
         isDead = true;
         transform.rotation = Quaternion.Euler(0f, 0f, -90f);
         GetComponent<PlayerAutoAttack>().enabled = false;
-        
+
         Debug.Log(gameObject.name + " has died.");
         CombatEvents.TriggerDeath(transform);
         // Implement respawn or game over logic here

--- a/Assets/game/Scripts/PlayerHealth.cs.meta
+++ b/Assets/game/Scripts/PlayerHealth.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5505fa8128ff21647a2370f75af612dd

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,7 +10,7 @@
     "com.unity.2d.tooling": "1.0.2",
     "com.unity.collab-proxy": "2.11.3",
     "com.unity.ide.rider": "3.0.39",
-    "com.unity.ide.visualstudio": "2.0.26",
+    "com.unity.ide.visualstudio": "2.0.27",
     "com.unity.inputsystem": "1.18.0",
     "com.unity.multiplayer.center": "1.0.1",
     "com.unity.render-pipelines.universal": "17.3.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -145,7 +145,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.26",
+      "version": "2.0.27",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
## Summary
Implements the foundational enemy attack combat loop for the Forsaken prototype.

Enemies can now:
- stop near the player
- attack on a timer
- apply damage through the combat event system
- react correctly to player death states

## Related Issue
Closes #66 

## Changes
- Added `PlayerHealth` component
- Added player damage processing through `CombatEvents.OnHit`
- Added player death handling
- Added visual player death state (sideways rotation)
- Disabled player auto attack after death
- Added enemy attack timer system
- Added configurable enemy attack range
- Connected enemy attacks to `CombatEvents`
- Used `EnemyStats.AttackDamage` for enemy damage
- Added enemy/player death state handling
- Prevented enemies from attacking after player death
- Prevented enemies from moving after player death
- Prevented spawner from spawning enemies after player death
- Added initialization checks for newly spawned enemies after player death
- Added validation checks for combat configuration values

## How to Test
Steps to verify this PR works:
- Open the combat prototype scene in Unity
- Press Play
- Verify enemies spawn normally
- Verify enemies move toward the player
- Verify enemies stop near the player instead of overlapping indefinitely
- Verify enemies attack the player repeatedly on a timer
- Verify player health decreases when hit
- Verify enemy attacks trigger combat event logs
- Verify changing `Attack Damage` in `SkeletonEnemyStats` changes damage dealt to the player
- Verify player dies when health reaches zero
- Verify player rotates sideways on death
- Verify player stops auto attacking after death
- Verify existing enemies stop moving after player death
- Verify existing enemies stop attacking after player death
- Verify newly spawned enemies do not move or attack after player death
- Verify enemy spawning stops completely after player death
- Verify no Console errors occur during combat flow

## Checklist
- [X] Scope is small and focused
- [X] Acceptance criteria met
- [X] No secrets committed
