### PR TITLE
Feature/story2.5

### DIFF
--- a/Assets/_Recovery/0 (2).unity
+++ b/Assets/_Recovery/0 (2).unity
@@ -293,7 +293,7 @@ Transform:
   m_GameObject: {fileID: 448238085}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 8.3, y: -5.8, z: 0}
+  m_LocalPosition: {x: 9.66, y: -5.4, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -312,13 +312,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemySpawner
   enemyPrefab: {fileID: 1971409653560928207, guid: bd86e0e549661464cb4545c8f023024c, type: 3}
-  spawnInterval: 5
-  maxActiveEnemies: 5
-  enemiesPerWave: 5
+  spawnInterval: 1
+  maxActiveEnemies: 10
+  enemiesPerWave: 3
   enemiesAddedPerWave: 1
   timeBetweenWaves: 3
   bossPrefab: {fileID: 5763772642368634643, guid: 0eefa5e28d29147ad8fda02ec509d1dc, type: 3}
-  bossWaveInterval: 5
+  bossWaveInterval: 3
   healthScalingPerWave: 0.15
   damageScalingPerWave: 0.1
 --- !u!1 &519420028
@@ -620,11 +620,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3431018974941178782, guid: 9b6135a0dd8140045ab175ad224ce2f3, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -5.69946
+      value: -3.7
       objectReference: {fileID: 0}
     - target: {fileID: 3431018974941178782, guid: 9b6135a0dd8140045ab175ad224ce2f3, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -5.8541403
+      value: -5.4
       objectReference: {fileID: 0}
     - target: {fileID: 3431018974941178782, guid: 9b6135a0dd8140045ab175ad224ce2f3, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -656,6 +656,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 5836857197505123814, guid: 9b6135a0dd8140045ab175ad224ce2f3, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1263484664}
+    - targetCorrespondingSourceObject: {fileID: 5836857197505123814, guid: 9b6135a0dd8140045ab175ad224ce2f3, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1263484666}
   m_SourcePrefab: {fileID: 100100000, guid: 9b6135a0dd8140045ab175ad224ce2f3, type: 3}
 --- !u!224 &1263484660 stripped
 RectTransform:
@@ -694,6 +697,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerHealth
   maxHealth: 100
+--- !u!114 &1263484666
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1263484661}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15e97f42494fa5546a22208c576a88c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CombatAnimationController
+  attackAnimationIndex: 0
+  deathAnimationIndex: 0
 --- !u!1 &1469452720
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Recovery/0 (2).unity.meta
+++ b/Assets/_Recovery/0 (2).unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e6954a85724e5b94c85c367688c93eda
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Recovery/0 (3).unity
+++ b/Assets/_Recovery/0 (3).unity
@@ -312,7 +312,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemySpawner
   enemyPrefab: {fileID: 1971409653560928207, guid: bd86e0e549661464cb4545c8f023024c, type: 3}
-  spawnInterval: 1
+  spawnInterval: 5
   maxActiveEnemies: 5
   enemiesPerWave: 5
   enemiesAddedPerWave: 1
@@ -696,7 +696,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5505fa8128ff21647a2370f75af612dd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerHealth
-  maxHealth: 150
+  maxHealth: 100
 --- !u!114 &1263484666
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Recovery/0 (3).unity.meta
+++ b/Assets/_Recovery/0 (3).unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d80487cfecb31934c93090aa0334bb32
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/game/Prefab/Characters/bossSkeleton.prefab
+++ b/Assets/game/Prefab/Characters/bossSkeleton.prefab
@@ -2650,6 +2650,7 @@ GameObject:
   - component: {fileID: -4707527262831189488}
   - component: {fileID: 5205642864470565458}
   - component: {fileID: -7747711896555164928}
+  - component: {fileID: 8552543471561540283}
   m_Layer: 5
   m_Name: bossSkeleton
   m_TagString: Enemy
@@ -5779,6 +5780,18 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0.3}
   m_Size: {x: 0.5, y: 1}
   m_Direction: 0
+--- !u!114 &8552543471561540283
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5763772642368634643}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 630e17643b8e76b42aeed6c0f4bf40fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EnemyRuntimeStats
 --- !u!1 &6204162632420780581
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/game/Prefab/Characters/skeletonEnemy.prefab
+++ b/Assets/game/Prefab/Characters/skeletonEnemy.prefab
@@ -1767,6 +1767,7 @@ GameObject:
   - component: {fileID: -4331950187728672861}
   - component: {fileID: -4632863046824613060}
   - component: {fileID: -1931486077432697664}
+  - component: {fileID: 5854508442767495695}
   m_Layer: 5
   m_Name: skeletonEnemy
   m_TagString: Enemy
@@ -4806,6 +4807,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::CombatAnimationController
   attackAnimationIndex: 0
   deathAnimationIndex: 0
+--- !u!114 &5854508442767495695
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971409653560928207}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 630e17643b8e76b42aeed6c0f4bf40fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EnemyRuntimeStats
 --- !u!1 &1987042151345004209
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/game/Scripts/EnemyHealth.cs
+++ b/Assets/game/Scripts/EnemyHealth.cs
@@ -6,6 +6,7 @@ public class EnemyHealth : MonoBehaviour
     private float currentHealth;
     private bool isDead = false;
     public EnemyStats EnemyStats => enemyStats;
+    private EnemyRuntimeStats runtimeStats;
 
     void OnEnable()
     {
@@ -19,13 +20,15 @@ public class EnemyHealth : MonoBehaviour
 
     void Start()
     {
-        if (enemyStats == null)
+        runtimeStats = GetComponent<EnemyRuntimeStats>();
+        if (runtimeStats != null && runtimeStats.MaxHealth > 0)
         {
-            Debug.LogError(gameObject.name + " is missing EnemyStats.");
-            enabled = false;
-            return;
+            currentHealth = runtimeStats.MaxHealth;
         }
-        currentHealth = enemyStats.MaxHealth;
+        else
+        {
+            currentHealth = enemyStats.MaxHealth;
+        }
     }
 
     void Update()

--- a/Assets/game/Scripts/EnemyHealth.cs
+++ b/Assets/game/Scripts/EnemyHealth.cs
@@ -5,6 +5,7 @@ public class EnemyHealth : MonoBehaviour
     [SerializeField] private EnemyStats enemyStats;
     private float currentHealth;
     private bool isDead = false;
+    public EnemyStats EnemyStats => enemyStats;
 
     void OnEnable()
     {

--- a/Assets/game/Scripts/EnemyRuntimeStats.cs
+++ b/Assets/game/Scripts/EnemyRuntimeStats.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+public class EnemyRuntimeStats : MonoBehaviour
+{
+    public float MaxHealth { get; private set; }
+    public float AttackDamage { get; private set; }
+    public float MovementSpeed { get; private set; }
+    public bool IsBoss { get; private set; }
+
+    public void Initialize(
+    float maxHealth,
+    float attackDamage,
+    float movementSpeed,
+    bool isBoss)
+    {
+        MaxHealth = maxHealth;
+        AttackDamage = attackDamage;
+        MovementSpeed = movementSpeed;
+        IsBoss = isBoss;
+    }
+}

--- a/Assets/game/Scripts/EnemyRuntimeStats.cs.meta
+++ b/Assets/game/Scripts/EnemyRuntimeStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 630e17643b8e76b42aeed6c0f4bf40fa

--- a/Assets/game/Scripts/EnemySpawner.cs
+++ b/Assets/game/Scripts/EnemySpawner.cs
@@ -134,7 +134,8 @@ public class EnemySpawner : MonoBehaviour
     void SpawnEnemy()
     {
         if (playerIsDead) return;
-        Instantiate(enemyPrefab, transform.position, Quaternion.identity);
+        GameObject enemy = Instantiate(enemyPrefab, transform.position, Quaternion.identity);
+        InitializeRuntimeStats(enemy);
         activeEnemyCount++;
         enemiesSpawnedThisWave++;
     }
@@ -215,5 +216,43 @@ public class EnemySpawner : MonoBehaviour
         bossSpawnedThisWave = true;
 
         Debug.Log("Boss spawned for Wave " + currentWave);
+    }
+    float GetHealthMultiplier()
+    {
+        return 1f + ((currentWave - 1) * healthScalingPerWave);
+    }
+
+    float GetDamageMultiplier()
+    {
+        return 1f + ((currentWave - 1) * damageScalingPerWave);
+    }
+    void InitializeRuntimeStats(GameObject enemy)
+    {
+        EnemyRuntimeStats runtimeStats = enemy.GetComponent<EnemyRuntimeStats>();
+        EnemyHealth enemyHealth = enemy.GetComponent<EnemyHealth>();
+
+        if (runtimeStats == null)
+        {
+            Debug.LogWarning(enemy.name + " is missing EnemyRuntimeStats.");
+            return;
+        }
+
+        if (enemyHealth == null || enemyHealth.EnemyStats == null)
+        {
+            Debug.LogWarning(enemy.name + " is missing EnemyHealth or EnemyStats.");
+            return;
+        }
+
+        EnemyStats baseStats = enemyHealth.EnemyStats;
+
+        float scaledHealth = baseStats.MaxHealth * GetHealthMultiplier();
+        float scaledDamage = baseStats.AttackDamage * GetDamageMultiplier();
+
+        runtimeStats.Initialize(
+            scaledHealth,
+            scaledDamage,
+            baseStats.MovementSpeed,
+            baseStats.IsBoss
+        );
     }
 }

--- a/Assets/game/Scripts/EnemySpawner.cs
+++ b/Assets/game/Scripts/EnemySpawner.cs
@@ -10,6 +10,8 @@ public class EnemySpawner : MonoBehaviour
     [SerializeField] private float timeBetweenWaves = 3f;
     [SerializeField] private GameObject bossPrefab;
     [SerializeField] private int bossWaveInterval = 5;
+    [SerializeField] private float healthScalingPerWave = 0.15f;
+    [SerializeField] private float damageScalingPerWave = 0.10f;
 
     bool bossSpawnedThisWave;
     private int currentWave = 1;
@@ -81,6 +83,8 @@ public class EnemySpawner : MonoBehaviour
         if (spawnInterval <= 0) spawnInterval = 1f;
         if (enemiesPerWave <= 0) enemiesPerWave = 1;
         if (timeBetweenWaves < 0) timeBetweenWaves = 0f;
+        if (healthScalingPerWave < 0) healthScalingPerWave = 0;
+        if (damageScalingPerWave < 0) damageScalingPerWave = 0;
 
 
         Debug.Log("Spawning enemy at: " + transform.position);

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -83,7 +83,7 @@ PlayerSettings:
   androidApplicationEntry: 2
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
-  runInBackground: 0
+  runInBackground: 1
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0
   Force IOS Speakers When Recording: 0


### PR DESCRIPTION
## Summary
Adds stage-based enemy stat scaling to support increasing combat difficulty as waves progress.

Enemies now receive runtime-scaled stats when spawned, allowing health and damage values to grow over time while keeping the base enemy data reusable.

## Changes
- Added configurable health and damage scaling per wave
- Added `EnemyRuntimeStats` for instance-specific enemy values
- Applied wave scaling when enemies are spawned
- Updated enemy health to use scaled runtime values

## How to Test
- Open the combat prototype scene
- Set health and damage scaling values in `EnemySpawner`
- Press Play
- Progress through multiple waves
- Verify enemy health increases on later waves
- Verify combat difficulty increases over time
- Verify no Console errors occur

## Checklist
- [x] Scope is small and focused
- [x] Acceptance criteria met
